### PR TITLE
feat: Add video detail page with comments section

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import { Outlet, Route, Routes } from 'react-router-dom';
 import Header from './components/Header.js';
 import SideBar from './components/SideBar.js';
 import Main from './Page/Main.js';
+import VideoDetail from './Page/VideoDetail.js';
 
 function App() {
   return (
@@ -10,6 +11,7 @@ function App() {
       <Routes>
         <Route path="/*" element={<AppLayout />} >
           <Route path='*' element={<Main/>}/>
+          <Route path='watch/:videoId' element={<VideoDetail/>}/>
         </Route>
       </Routes>
     </div>

--- a/src/Page/Home.js
+++ b/src/Page/Home.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import {getRecommendedVideos, getChannelData} from '../api.js'
 import MovieList from '../components/MovieList.js';
 import './Home.css'
+import { Link } from 'react-router-dom';
 
 export default function Home() {
   const [videos, setVideos] = useState([]);
@@ -17,7 +18,11 @@ export default function Home() {
         
         const channelImages = await Promise.all(
           data.items.map(async (video) => {
-            const profileImage = await getChannelData(video.snippet.channelId);
+            const channelData = await getChannelData(video.snippet.channelId);
+            console.log(channelData);
+            const profileImage = channelData.items[0]?.snippet?.thumbnails?.default?.url;
+            
+            console.log(profileImage);
             return profileImage || "default_image_url_here";  // 기본 이미지를 반환
           })
         );
@@ -42,12 +47,13 @@ export default function Home() {
       {videos.length > 0 ? (
         <div className="video-container">
           {videos.map((video, index) => (
-
+            <Link to={`/watch/${video.id}`}>
             <MovieList
               key={video.id}
               video={video}
               profileImage={profileImages[index]}
               />
+              </Link>
 
           ))}
         </div>

--- a/src/Page/VideoDetail.css
+++ b/src/Page/VideoDetail.css
@@ -1,0 +1,151 @@
+.video_container{
+    display: flex;
+    padding:20px;
+    height: 100%;
+    width: 100%;
+}
+.video_section{
+    width: 70%;
+    display: flex;
+    flex-direction: column;
+}
+.video_player{
+    position: relative;
+    width: 100%;
+    padding-top: 56.25%;
+}
+.video_player iframe{
+    position: absolute;
+    top:0;
+    left:0;
+    width: 100%;
+    height: 100%;
+    border-radius: 15px;
+}
+.video_detail{
+    height:50px;
+    padding:10px 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+.channel_detail{
+    display: flex;
+    gap:20px;
+}
+.channel_info{
+    display: flex;
+    gap:10px;
+    height: 100%;
+    padding:10px 0;
+}
+.channel_logo{
+    display: flex;
+    align-items: center;
+
+}
+.channel_logo img{
+    width:50px;
+    height:50px;
+    border-radius: 50%;
+    object-fit: cover;
+}
+.channel_description{
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    text-overflow: ellipsis;
+}
+.channel_title{
+    font-size: 16px;
+}
+.channel_subscription_count{
+    font-size: 13px;
+    color: rgb(104, 104, 104);
+}
+.channel_subscription{
+    display: flex;
+    align-items: center;
+}
+.channel_subscription button{
+    background-color: black;
+    color: white;
+    cursor: pointer;
+    width:55px;
+    height: 35px;
+    border:none;
+    border-radius: 30px;
+}
+.channel_subscription button:hover{
+    opacity: 0.8;
+}
+.video_function{
+    display: flex;
+    gap: 10px;
+    height:30px;
+}
+.video_function > div{
+    border-radius: 20px;
+    background-color: rgb(240, 240, 240);
+    display: flex;
+    align-items: center;
+    gap:10px;
+    padding: 0 10px;
+}
+@media (max-width:1500px){
+    .hide_first{
+        display: none !important;
+    }
+}
+@media (max-width:1024px) {
+    .hide_last{
+        display: none !important;
+    }
+    .video_section{
+        width: 100%;
+    }
+}
+.video_description{
+    display: flex;
+    flex-direction: column;
+    padding: 10px;
+    gap:10px;
+    border-radius: 10px;
+    background-color: rgb(240, 240, 240);
+}
+.video_description_content.hidden{
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.video_description_header{
+    display: flex;
+    gap:10px;
+}
+.video_description_toggle{
+    border:none;
+    background-color: transparent;
+    cursor: pointer;
+    display: flex;
+}
+.video_comment{
+    padding: 10px 0;
+    display: flex;
+    flex-direction: column;
+    gap:20px;
+    margin-top:20px;
+}
+.video_comment_section{
+    display: flex;
+    gap:10px;
+}
+.video_comment_data{
+    display: flex;
+    flex-direction: column;
+}
+.comment_data_header{
+    display: flex;
+    gap:10px;
+}

--- a/src/Page/VideoDetail.js
+++ b/src/Page/VideoDetail.js
@@ -1,0 +1,131 @@
+import React, { useEffect, useState } from 'react'
+import { getChannelData, getCommentData, getVideoData } from '../api.js'
+import './VideoDetail.css'
+import { AiOutlineDislike, AiOutlineLike } from 'react-icons/ai';
+import { RxDividerVertical } from 'react-icons/rx';
+import { PiScissorsLight, PiShareFatLight } from 'react-icons/pi';
+import { IoIosMore } from 'react-icons/io';
+import { GiSaveArrow } from 'react-icons/gi';
+import { CiBookmark } from 'react-icons/ci';
+import { useParams } from 'react-router-dom';
+import { formatViews, timeAgo } from '../utils/VideoFunctions.js';
+
+export default function VideoDetail() {
+  const {videoId} = useParams();
+  const [descriptionIsHidden,setDesciptionHidden] = useState(true);
+    const [videoData,setVideoData] = useState([]);
+    const [channelData,setChannelData] = useState([]);
+    const [commentList,setCommentList] = useState([]);
+    useEffect(() => {
+        async function fetchVideos() {
+          try {
+            const data = await getVideoData(videoId); // 비동기 API 호출
+            setVideoData(data.items[0]);
+            fetchChannel(data.items[0].snippet?.channelId);
+          } catch (error){}
+        }
+        async function fetchChannel(channelId) {
+            try {
+              const data = await getChannelData(channelId); // 비동기 API 호출
+              setChannelData(data.items[0]);
+            } catch (error){}
+          }
+        fetchVideos();
+        async function fetchComments() {
+          try {
+            const data = await getCommentData(videoId); // 비동기 API 호출
+            console.log(data);
+            setCommentList(data.items);
+          } catch (error){}
+        }
+      fetchVideos();
+        fetchComments();
+      },[]);
+    return (
+    <div className='video_container'>
+        {/* 왼쪽 */}
+        <div className='video_section'>
+          <div className='video_player'>
+          <iframe id="ytplayer" type="text/html" width="1500" height="1000" title='test'
+      src={`https://www.youtube.com/embed/${videoId}?autoplay=1&origin=http://example.com`}
+      frameborder="0"/>
+          </div>
+
+        {/* 타이틀 */}
+        <div className='video_title'>
+        <h3>{videoData.snippet?.localized?.title}</h3>
+        </div>
+        <div className='video_detail'>
+            {/* 채널명 > 구독, 좋아요, 공유, 더보기 */}
+            <div className='channel_detail'>
+              <div className='channel_info'>
+                <div className='channel_logo'>
+                      <img src={channelData.snippet?.thumbnails?.default?.url} alt='channel_image'/>
+                  </div>
+                  <div className='channel_description'>
+                      <span className='channel_title'>{channelData.snippet?.title}</span>
+                      <span className='channel_subscription_count'>구독자 {channelData.statistics?.subscriberCount}</span>
+                  </div>
+              </div>
+                <div className='channel_subscription'>
+                  <button>구독</button>
+                </div>
+            </div>
+            <div className='video_function'>
+              <div className='video_likes'>
+                  <AiOutlineLike/>
+                  {formatViews(videoData.statistics?.likeCount)}
+                  <RxDividerVertical/>
+                  <AiOutlineDislike/>
+              </div>
+              <div><PiShareFatLight/>공유</div>
+              {/* 화면에 따라 숨겨야 할것 */}
+              <div className='hide_first'><GiSaveArrow/>오프라인 저장</div>
+              <div className='hide_first'><PiScissorsLight/>클립</div>
+              <div className='hide_last'><CiBookmark/>저장</div>
+              <div className="hide_last"><IoIosMore/></div>
+            </div>
+
+        </div>
+        {/* 설명 */}
+        <div className='video_description'>
+        <div className='video_description_header'>
+        <span>조회수 {(formatViews(videoData.statistics?.viewCount))}</span>
+        <span>{timeAgo(videoData.snippet?.publishedAt)}</span>
+        </div>
+          <div className={`video_description_content ${descriptionIsHidden && "hidden"}`}>
+          {videoData.snippet?.description.split('\n').map((line, index) => (
+      <React.Fragment key={index}>
+        {line}
+        <br />
+      </React.Fragment>
+    ))}
+          </div>
+
+        <button className="video_description_toggle"onClick={()=>{setDesciptionHidden((prev)=>!prev)}}>{descriptionIsHidden ? "더보기" : "간략히"}</button>
+        </div>
+        <div className='video_comment'>
+          {
+            commentList.map(comment=>(
+              <div  className="video_comment_section" key={comment.id}>
+                <div className='channel_logo'>
+                <span><img src={comment.snippet?.topLevelComment?.snippet?.authorProfileImageUrl} alt='comment_profile'></img></span>
+                  </div>
+                <div className='video_comment_data'>
+                  <div className='comment_data_header'>
+                  <span>{timeAgo(comment.snippet?.topLevelComment?.snippet?.updatedAt)}</span>
+                  <span>{comment.snippet?.topLevelComment?.snippet?.authorDisplayName}</span>
+                </div>
+                <div className='comment_data_text' dangerouslySetInnerHTML={{__html:comment.snippet?.topLevelComment?.snippet?.textDisplay}}>
+                  </div>
+                </div>
+
+              </div>
+            ))
+          }
+        </div>
+        </div>
+    </div>
+  )
+
+}

--- a/src/Page/VideoDetail.js
+++ b/src/Page/VideoDetail.js
@@ -1,131 +1,52 @@
-import React, { useEffect, useState } from 'react'
-import { getChannelData, getCommentData, getVideoData } from '../api.js'
-import './VideoDetail.css'
-import { AiOutlineDislike, AiOutlineLike } from 'react-icons/ai';
-import { RxDividerVertical } from 'react-icons/rx';
-import { PiScissorsLight, PiShareFatLight } from 'react-icons/pi';
-import { IoIosMore } from 'react-icons/io';
-import { GiSaveArrow } from 'react-icons/gi';
-import { CiBookmark } from 'react-icons/ci';
+// VideoDetail.js
+import React, { useEffect, useState } from 'react';
+import { getChannelData, getCommentData, getVideoData } from '../api.js';
+import './VideoDetail.css';
 import { useParams } from 'react-router-dom';
-import { formatViews, timeAgo } from '../utils/VideoFunctions.js';
+import VideoContent from '../components/VideoContent.js';
+import CommentList from '../components/CommentList.js'; // CommentList 컴포넌트 임포트
 
 export default function VideoDetail() {
-  const {videoId} = useParams();
-  const [descriptionIsHidden,setDesciptionHidden] = useState(true);
-    const [videoData,setVideoData] = useState([]);
-    const [channelData,setChannelData] = useState([]);
-    const [commentList,setCommentList] = useState([]);
-    useEffect(() => {
-        async function fetchVideos() {
+  const { videoId } = useParams();
+  const [videoData,setVideoData] = useState([]);
+  const [channelData,setChannelData] = useState([]);
+  const [commentList, setCommentList] = useState([]);
+
+  useEffect(() => {
+    async function fetchComments() {
+      try {
+        const data = await getCommentData(videoId); // 비동기 API 호출
+        setCommentList(data.items);
+      } catch (error) {
+        // 에러 처리
+      }
+    }
+      async function fetchVideos() {
+        try {
+          const data = await getVideoData(videoId); // 비동기 API 호출
+          console.log(data.items[0]);
+          setVideoData(data.items[0]);
+          fetchChannel(data.items[0].snippet?.channelId);
+        } catch (error){}
+      }
+      async function fetchChannel(channelId) {
           try {
-            const data = await getVideoData(videoId); // 비동기 API 호출
-            setVideoData(data.items[0]);
-            fetchChannel(data.items[0].snippet?.channelId);
-          } catch (error){}
-        }
-        async function fetchChannel(channelId) {
-            try {
-              const data = await getChannelData(channelId); // 비동기 API 호출
-              setChannelData(data.items[0]);
-            } catch (error){}
-          }
-        fetchVideos();
-        async function fetchComments() {
-          try {
-            const data = await getCommentData(videoId); // 비동기 API 호출
-            console.log(data);
-            setCommentList(data.items);
+            const data = await getChannelData(channelId); // 비동기 API 호출
+            setChannelData(data.items[0]);
           } catch (error){}
         }
       fetchVideos();
-        fetchComments();
-      },[]);
-    return (
-    <div className='video_container'>
-        {/* 왼쪽 */}
-        <div className='video_section'>
-          <div className='video_player'>
-          <iframe id="ytplayer" type="text/html" width="1500" height="1000" title='test'
-      src={`https://www.youtube.com/embed/${videoId}?autoplay=1&origin=http://example.com`}
-      frameborder="0"/>
-          </div>
+    fetchVideos();
+    fetchComments();
+  }, [videoId]);
 
-        {/* 타이틀 */}
-        <div className='video_title'>
-        <h3>{videoData.snippet?.localized?.title}</h3>
-        </div>
-        <div className='video_detail'>
-            {/* 채널명 > 구독, 좋아요, 공유, 더보기 */}
-            <div className='channel_detail'>
-              <div className='channel_info'>
-                <div className='channel_logo'>
-                      <img src={channelData.snippet?.thumbnails?.default?.url} alt='channel_image'/>
-                  </div>
-                  <div className='channel_description'>
-                      <span className='channel_title'>{channelData.snippet?.title}</span>
-                      <span className='channel_subscription_count'>구독자 {channelData.statistics?.subscriberCount}</span>
-                  </div>
-              </div>
-                <div className='channel_subscription'>
-                  <button>구독</button>
-                </div>
-            </div>
-            <div className='video_function'>
-              <div className='video_likes'>
-                  <AiOutlineLike/>
-                  {formatViews(videoData.statistics?.likeCount)}
-                  <RxDividerVertical/>
-                  <AiOutlineDislike/>
-              </div>
-              <div><PiShareFatLight/>공유</div>
-              {/* 화면에 따라 숨겨야 할것 */}
-              <div className='hide_first'><GiSaveArrow/>오프라인 저장</div>
-              <div className='hide_first'><PiScissorsLight/>클립</div>
-              <div className='hide_last'><CiBookmark/>저장</div>
-              <div className="hide_last"><IoIosMore/></div>
-            </div>
-
-        </div>
-        {/* 설명 */}
-        <div className='video_description'>
-        <div className='video_description_header'>
-        <span>조회수 {(formatViews(videoData.statistics?.viewCount))}</span>
-        <span>{timeAgo(videoData.snippet?.publishedAt)}</span>
-        </div>
-          <div className={`video_description_content ${descriptionIsHidden && "hidden"}`}>
-          {videoData.snippet?.description.split('\n').map((line, index) => (
-      <React.Fragment key={index}>
-        {line}
-        <br />
-      </React.Fragment>
-    ))}
-          </div>
-
-        <button className="video_description_toggle"onClick={()=>{setDesciptionHidden((prev)=>!prev)}}>{descriptionIsHidden ? "더보기" : "간략히"}</button>
-        </div>
-        <div className='video_comment'>
-          {
-            commentList.map(comment=>(
-              <div  className="video_comment_section" key={comment.id}>
-                <div className='channel_logo'>
-                <span><img src={comment.snippet?.topLevelComment?.snippet?.authorProfileImageUrl} alt='comment_profile'></img></span>
-                  </div>
-                <div className='video_comment_data'>
-                  <div className='comment_data_header'>
-                  <span>{timeAgo(comment.snippet?.topLevelComment?.snippet?.updatedAt)}</span>
-                  <span>{comment.snippet?.topLevelComment?.snippet?.authorDisplayName}</span>
-                </div>
-                <div className='comment_data_text' dangerouslySetInnerHTML={{__html:comment.snippet?.topLevelComment?.snippet?.textDisplay}}>
-                  </div>
-                </div>
-
-              </div>
-            ))
-          }
-        </div>
-        </div>
+  return (
+    <div className="video_container">
+      {/* 왼쪽 */}
+      <div className="video_section">
+        <VideoContent video={videoData} channel = {channelData}/>
+        <CommentList commentList={commentList} />
+      </div>
     </div>
-  )
-
+  );
 }

--- a/src/api.js
+++ b/src/api.js
@@ -44,7 +44,7 @@ export async function getRecommendedVideos() {
 export async function getChannelData(channelId) {
     const url = "https://www.googleapis.com/youtube/v3/channels";
     const params = new URLSearchParams({
-        part: "snippet",
+        part: "snippet,statistics",
         id: channelId,
         key: YOUTUBE_API_KEY
     });
@@ -52,9 +52,39 @@ export async function getChannelData(channelId) {
     try {
         const response = await fetch(`${url}?${params}`);
         const data = await response.json();
-        if (data.items && data.items.length > 0) {
-            return data.items[0].snippet.thumbnails.default.url;
-        }
+        return data;
+    } catch (error) {
+        console.error("채널 정보 가져오기 중 오류 발생:", error);
+    }
+}
+export async function getVideoData(videoId) {
+    const url = "https://www.googleapis.com/youtube/v3/videos";
+    const params = new URLSearchParams({
+        part: "snippet,statistics",
+        id: videoId,
+        key: YOUTUBE_API_KEY
+    });
+
+    try {
+        const response = await fetch(`${url}?${params}`);
+        const data = await response.json();
+        return data;
+    } catch (error) {
+        console.error("채널 정보 가져오기 중 오류 발생:", error);
+    }
+}
+export async function getCommentData(videoId) {
+    const url = "https://www.googleapis.com/youtube/v3/commentThreads";
+    const params = new URLSearchParams({
+        part: "snippet",
+        videoId:videoId,
+        key: YOUTUBE_API_KEY,
+    });
+
+    try {
+        const response = await fetch(`${url}?${params}`);
+        const data = await response.json();
+        return data;
     } catch (error) {
         console.error("채널 정보 가져오기 중 오류 발생:", error);
     }

--- a/src/components/CommentList.js
+++ b/src/components/CommentList.js
@@ -1,0 +1,36 @@
+// CommentList.js
+import React, { useMemo } from 'react';
+import { timeAgo } from '../utils/VideoFunctions.js';
+
+const CommentList = ({ commentList }) => {
+  const optimizedComments = useMemo(() => {
+    return commentList.map((comment) => (
+      <div className="video_comment_section" key={comment.id}>
+        <div className="channel_logo">
+          <span>
+            <img
+              src={comment.snippet?.topLevelComment?.snippet?.authorProfileImageUrl}
+              alt="comment_profile"
+            />
+          </span>
+        </div>
+        <div className="video_comment_data">
+          <div className="comment_data_header">
+            <span>{timeAgo(comment.snippet?.topLevelComment?.snippet?.updatedAt)}</span>
+            <span>{comment.snippet?.topLevelComment?.snippet?.authorDisplayName}</span>
+          </div>
+          <div
+            className="comment_data_text"
+            dangerouslySetInnerHTML={{
+              __html: comment.snippet?.topLevelComment?.snippet?.textDisplay,
+            }}
+          ></div>
+        </div>
+      </div>
+    ));
+  }, [commentList]);
+
+  return <div className="video_comment">{optimizedComments}</div>;
+};
+
+export default CommentList;

--- a/src/components/MovieList.js
+++ b/src/components/MovieList.js
@@ -1,45 +1,10 @@
 import React from 'react'
 import './MovieList.css'
+import { formatViews, timeAgo } from '../utils/VideoFunctions.js'
 
 export default function MovieList({ video, profileImage }) {
-
   // 시간 변환 함수
-  function timeAgo(publishedAt) {
-    const now = new Date();
-    const publishedDate = new Date(publishedAt);
-    const diffInSeconds = Math.floor((now - publishedDate) / 1000);
 
-    const timeUnits = [
-      { unit: "년", seconds: 60 * 60 * 24 * 365 },
-      { unit: "개월", seconds: 60 * 60 * 24 * 30 },
-      { unit: "일", seconds: 60 * 60 * 24 },
-      { unit: "시간", seconds: 60 * 60 },
-      { unit: "분", seconds: 60 },
-    ];
-
-    for (const { unit, seconds } of timeUnits) {
-      const amount = Math.floor(diffInSeconds / seconds);
-      if (amount >= 1) {
-        return `${amount}${unit} 전`;
-      }
-    }
-    return "방금 전";
-  }
-
-  // 숫자 축약 함수
-  function formatViews(views) {
-    if (views >= 1_000_000_000) {
-      return (views / 1_000_000_000).toFixed(1) + "억회";
-    } else if (views >= 1_000_000) {
-      return (views / 1_000_000).toFixed(1) + "백만회";
-    } else if (views >= 10_000) {
-      return (views / 10_000).toFixed(1) + "만회";
-    } else if (views >= 1_000) {
-      return (views / 1_000).toFixed(1) + "천회";
-    } else {
-      return views + "회";
-    }
-  }
 
   return (
     <div key={video.id} className="video-item">

--- a/src/components/SideBar.css
+++ b/src/components/SideBar.css
@@ -3,7 +3,6 @@
     width: 100%;
     height: 100vh;
     overflow: hidden;
-    
   }
   
   .sidebar {

--- a/src/components/VideoContent.js
+++ b/src/components/VideoContent.js
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from 'react'
+import { AiOutlineDislike, AiOutlineLike } from 'react-icons/ai';
+import { RxDividerVertical } from 'react-icons/rx';
+import { PiScissorsLight, PiShareFatLight } from 'react-icons/pi';
+import { IoIosMore } from 'react-icons/io';
+import { GiSaveArrow } from 'react-icons/gi';
+import { CiBookmark } from 'react-icons/ci';
+import { formatViews, timeAgo } from '../utils/VideoFunctions.js';
+
+export default function VideoContent({video,channel}) {
+    const [descriptionIsHidden,setDesciptionHidden] = useState(true);
+  return (
+    <div><div className='video_player'>
+    <iframe id="ytplayer" type="text/html" width="1500" height="1000" title='test'
+src={`https://www.youtube.com/embed/${video.id}?autoplay=1&origin=http://example.com`}
+frameborder="0"/>
+    </div>
+
+  {/* 타이틀 */}
+  <div className='video_title'>
+  <h3>{video.snippet?.localized?.title}</h3>
+  </div>
+  <div className='video_detail'>
+      {/* 채널명 > 구독, 좋아요, 공유, 더보기 */}
+      <div className='channel_detail'>
+        <div className='channel_info'>
+          <div className='channel_logo'>
+                <img src={channel.snippet?.thumbnails?.default?.url} alt='channel_image'/>
+            </div>
+            <div className='channel_description'>
+                <span className='channel_title'>{channel.snippet?.title}</span>
+                <span className='channel_subscription_count'>구독자 {channel.statistics?.subscriberCount}</span>
+            </div>
+        </div>
+          <div className='channel_subscription'>
+            <button>구독</button>
+          </div>
+      </div>
+      <div className='video_function'>
+        <div className='video_likes'>
+            <AiOutlineLike/>
+            {formatViews(video.statistics?.likeCount)}
+            <RxDividerVertical/>
+            <AiOutlineDislike/>
+        </div>
+        <div><PiShareFatLight/>공유</div>
+        {/* 화면에 따라 숨겨야 할것 */}
+        <div className='hide_first'><GiSaveArrow/>오프라인 저장</div>
+        <div className='hide_first'><PiScissorsLight/>클립</div>
+        <div className='hide_last'><CiBookmark/>저장</div>
+        <div className="hide_last"><IoIosMore/></div>
+      </div>
+
+  </div>
+  {/* 설명 */}
+  <div className='video_description'>
+  <div className='video_description_header'>
+  <span>조회수 {(formatViews(video.statistics?.viewCount))}</span>
+  <span>{timeAgo(video.snippet?.publishedAt)}</span>
+  </div>
+    <div className={`video_description_content ${descriptionIsHidden && "hidden"}`}>
+    {video.snippet?.description.split('\n').map((line, index) => (
+<React.Fragment key={index}>
+  {line}
+  <br />
+</React.Fragment>
+))}
+    </div>
+
+  <button className="video_description_toggle"onClick={()=>{setDesciptionHidden((prev)=>!prev)}}>{descriptionIsHidden ? "더보기" : "간략히"}</button>
+  </div></div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -11,3 +11,7 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+a{
+  text-decoration: inherit;
+  color:inherit;
+}

--- a/src/utils/VideoFunctions.js
+++ b/src/utils/VideoFunctions.js
@@ -1,0 +1,36 @@
+ export function timeAgo(publishedAt) {
+    const now = new Date();
+    const publishedDate = new Date(publishedAt);
+    const diffInSeconds = Math.floor((now - publishedDate) / 1000);
+
+    const timeUnits = [
+      { unit: "년", seconds: 60 * 60 * 24 * 365 },
+      { unit: "개월", seconds: 60 * 60 * 24 * 30 },
+      { unit: "일", seconds: 60 * 60 * 24 },
+      { unit: "시간", seconds: 60 * 60 },
+      { unit: "분", seconds: 60 },
+    ];
+
+    for (const { unit, seconds } of timeUnits) {
+      const amount = Math.floor(diffInSeconds / seconds);
+      if (amount >= 1) {
+        return `${amount}${unit} 전`;
+      }
+    }
+    return "방금 전";
+  }
+
+  // 숫자 축약 함수
+export function formatViews(views) {
+    if (views >= 1_000_000_000) {
+      return (views / 1_000_000_000).toFixed(1) + "억회";
+    } else if (views >= 1_000_000) {
+      return (views / 1_000_000).toFixed(1) + "백만회";
+    } else if (views >= 10_000) {
+      return (views / 10_000).toFixed(1) + "만회";
+    } else if (views >= 1_000) {
+      return (views / 1_000).toFixed(1) + "천회";
+    } else {
+      return views + "회";
+    }
+  }


### PR DESCRIPTION
## 📌 Summary
- video detail Page 생성

## ✅ Changes
- app 라우터 videoDetailPage 추가 => VideoContent,CommentList 컴포넌트 분리
- CommentList=> useMemo를 이용해 성능 최적화
- api 함수 댓글, 비디오 함수 추가
- 자주 사용되는 함수 분리 (videoList => formatView, timeAgo)
- api  함수 수정 (기존: 채널 함수(프로필 가져오기) => 변경(채널 데이터 가져오기))에 따른 home 프로필 함수 수정

## 🚀 How to Test
1. `git clone` 후 해당 브랜치 확인
2. `npm install && npm start` 실행 후 정상 동작 확인

## Error
1. App의 resize 함수 에러 발견
2. sideBar.css는 변경내용 없는데 잘못 푸시함